### PR TITLE
Request glucose level entry via sms feature

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -1,5 +1,5 @@
 import nexmo
-import json
+import json, ast
 import os
 from flask import Flask, request, jsonify, render_template, session, redirect, url_for
 from flask_cors import CORS


### PR DESCRIPTION
From now on, users can request the glucose level via SMS whenever they want. 

All they need is a Vonage application with an associated number, and a server to manage the SMS requests; for this, you can use Ngrok (+ info: https://bit.ly/30NkTE6).

The endpoint defined to manage the SMS Webhook is: _**/webhooks/inbound-messages**_

To guarantee the functionality of the integration, users have to send the following message to the number associated with the application -> "**_Nightscout return the latest blood glucose level entry_**"